### PR TITLE
Set explicit tab size in EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = tab
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.json]


### PR DESCRIPTION
GitHub will respect the tabs, but only use 4 characters widths instead of the default 8 when rendering on the web