### PR TITLE
Added support for passing tags through

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Default value:
 ```
 {
   browser: 'firefox',
-  threshold: 0
+  threshold: 0,
+  tags: null
 }
 ```
 
@@ -59,6 +60,12 @@ Type: `String`
 Default value: `firefox`
 
 Which browser to run the tests in
+
+#### tags
+Type: `String` or `Array[String]`
+Default value: `null`
+
+Which tags to filter violations on
 
 ### urls
 Type: `Array[String]`
@@ -111,6 +118,37 @@ grunt.initConfig({
       urls: ['http://localhost:9876/tests/test1.html', 'http://localhost:9876/tests/test2.html'],
     }
   },
+});
+```
+
+#### Tag filtering
+##### Single
+In this example, the only violations that will be checked for are those that have the matching tag.
+```js
+grunt.initConfig({
+  "axe-webdriver": {
+    firefox: {
+      options: {
+        tags: 'wcag2a'
+      },
+      urls: ['http://localhost:9876/tests/test1.html', 'http://localhost:9876/tests/test2.html']
+    }
+  }
+});
+```
+
+##### Multiple
+In this example, the only violations that will be checked for are those that have one of the matching tags.
+```js
+grunt.initConfig({
+  "axe-webdriver": {
+    firefox: {
+      options: {
+        tags: ['wcag2a', 'wcag2aa']
+      },
+      urls: ['http://localhost:9876/tests/test1.html', 'http://localhost:9876/tests/test2.html']
+    }
+  }
 });
 ```
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,7 +6,8 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 	var options = this.options({
 		browser: 'firefox',
 		server: null,
-		threshold: 0
+		threshold: 0,
+		tags: null
 	});
 
 	var done = this.async();
@@ -23,6 +24,7 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 				.then(function() {
 					var startTimestamp = new Date().getTime();
 					new AxeBuilder(driver)
+						.withTags(options.tags)
 						.analyze(function(results) {
 							results.url = url;
 							// The "new Date()" timestamp in axe-core is, here, an empty object...

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -10,6 +10,9 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 		tags: null
 	});
 
+	var tagsAreDefined = 
+		(!Array.isArray(options.tags) && options.tags !== null && options.tags !== '') || 
+		(Array.isArray(options.tags) && options.tags.length > 0);
 	var done = this.async();
 	var driver = new WebDriver.Builder()
 		.forBrowser(options.browser)
@@ -23,8 +26,13 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 				.get(url)
 				.then(function() {
 					var startTimestamp = new Date().getTime();
-					new AxeBuilder(driver)
-						.withTags(options.tags)
+					var axeBuilder = new AxeBuilder(driver);
+					
+					if (tagsAreDefined) {
+						axeBuilder.withTags(options.tags);
+					}
+					
+					axeBuilder
 						.analyze(function(results) {
 							results.url = url;
 							// The "new Date()" timestamp in axe-core is, here, an empty object...

--- a/test/unit/runner.js
+++ b/test/unit/runner.js
@@ -280,4 +280,44 @@ describe('runner', function () {
 
 		runner.call(that, grunt, WebDriver, Promise, AxeBuilder, reporter);
 	});
+	it('Should not call AxeBuilder.withTags when options.tags is an empty string', function (done) {
+		CheckWithTagsIsNotCalled(done, '');
+	});
+	it('Should not call AxeBuilder.withTags when options.tags is null', function (done) {
+		CheckWithTagsIsNotCalled(done, null);
+	});
+	it('Should not call AxeBuilder.withTags when options.tags is an empty array', function (done) {
+		CheckWithTagsIsNotCalled(done, []);
+	});
+	
+	function CheckWithTagsIsNotCalled(done, tags) {
+		var last,
+			that = {
+				options: function () {
+					return {
+						tags: tags
+					};
+				},
+				async: function () {
+					return last
+				},
+				data : {
+					dest: undefined,
+					urls: ['one url']
+				}
+			},
+			grunt = {},
+			reporter = function () {},
+			original = AxeBuilder.prototype.withTags;
+
+		AxeBuilder.prototype.withTags = sinon.stub();
+
+		last = function () {
+			AxeBuilder.prototype.withTags.called.should.be.false();
+			AxeBuilder.prototype.withTags = original;
+			done();
+		};
+
+		runner.call(that, grunt, WebDriver, Promise, AxeBuilder, reporter);
+	}
 });

--- a/test/unit/runner.js
+++ b/test/unit/runner.js
@@ -28,6 +28,9 @@ describe('runner', function () {
 	AxeBuilder.prototype.analyze = function (cb) {
 		cb({});
 	};
+	AxeBuilder.prototype.withTags = function (tags) {
+		return this;
+	};
 
 	beforeEach(function() {
 	  this.sinon = sinon.sandbox.create();
@@ -208,6 +211,73 @@ describe('runner', function () {
 			AxeBuilder.prototype.analyze = original;
 			done();
 		};
+		runner.call(that, grunt, WebDriver, Promise, AxeBuilder, reporter);
+	});
+	it('Should pass single options.tags as a string to AxeBuilder.withTags', function (done) {
+		var last, tags,
+			that = {
+				options: function () {
+					return {
+						tags: 'TagToCheck'
+					};
+				},
+				async: function () {
+					return last
+				},
+				data : {
+					dest: undefined,
+					urls: ['one url']
+				}
+			},
+			grunt = {},
+			reporter = function () {},
+			original = AxeBuilder.prototype.withTags;
+
+		AxeBuilder.prototype.withTags = function (_tags) {
+			tags = _tags;
+			return this;
+		};
+
+		last = function () {
+			tags.should.equal('TagToCheck');
+			AxeBuilder.prototype.withTags = original;
+			done();
+		};
+
+		runner.call(that, grunt, WebDriver, Promise, AxeBuilder, reporter);
+	});
+	it('Should pass multiple options.tags as an array of strings to AxeBuilder.withTags', function (done) {
+		var last, tags,
+			that = {
+				options: function () {
+					return {
+						tags: ['FirstTagToCheck', 'SecondTagToCheck']
+					};
+				},
+				async: function () {
+					return last
+				},
+				data : {
+					dest: undefined,
+					urls: ['one url']
+				}
+			},
+			grunt = {},
+			reporter = function () {},
+			original = AxeBuilder.prototype.withTags;
+
+		AxeBuilder.prototype.withTags = function (_tags) {
+			tags = _tags;
+			return this;
+		};
+
+		last = function () {
+			tags[0].should.equal('FirstTagToCheck');
+			tags[1].should.equal('SecondTagToCheck');
+			AxeBuilder.prototype.withTags = original;
+			done();
+		};
+
 		runner.call(that, grunt, WebDriver, Promise, AxeBuilder, reporter);
 	});
 });


### PR DESCRIPTION
Currently only concerned about the wcag2a violations so needed a way of restricting what this module checks. I also noticed someone else had requested this feature (#13) so thought I would give it a go.

One thing I am not sure about is whether the validation around tags should be done in this module or within the withTags method itself in the [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) module. Let me know what you think.