### PR TITLE
Add chromedriver via npm to avoid path problems

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var junitReporter = require('./junitReporter');
+require('chromedriver');
 
 module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 	var options = this.options({

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   ],
   "dependencies": {
     "axe-webdriverjs": "~0.2.0",
+    "chromedriver": "^2.23.0",
     "junit-report-builder": "^1.1.1",
     "promise": "^7.0.1",
     "selenium-webdriver": "^2.46.0"


### PR DESCRIPTION
When you run with chrome, you can obtain this error:

`Running "axe-webdriver:chrome" (axe-webdriver) task
Warning: The ChromeDriver could not be found on the current PATH. Please download the latest version of the ChromeDriver from http://chromedriver.storage.googleapis.com/index.html and ensure it can be found on your PATH. Use --force to continue.`

To avoid it, you can donwload the driver by yourself and setting the PATH. 

I´ve added the driver via npm package to avoid the user to do this.