### PR TITLE
Update axe-webdriverjs to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "axe-webdriverjs": "~0.2.0",
+    "axe-webdriverjs": "^1.1.0",
     "chromedriver": "^2.23.0",
     "junit-report-builder": "^1.1.1",
     "promise": "^7.0.1",

--- a/test/unit/runner.js
+++ b/test/unit/runner.js
@@ -15,6 +15,9 @@ describe('runner', function () {
 	WebDriver.Builder.prototype.forBrowser = function () {
 		return this;
 	};
+	WebDriver.Builder.prototype.usingServer = function () {
+		return this;
+	};
 	WebDriver.Builder.prototype.build = function () {
 		return this;
 	};


### PR DESCRIPTION
@dylanb should we wait to update this module after merging this PR and doing another release?https://github.com/dequelabs/axe-webdriverjs/pull/37

The reason being, there's quite a bit of extra noise when you install the latest version of axe-webdriverjs. 