### PR TITLE
Fix #27: Upgrade selenium-webdriver to get Firefox working

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chromedriver": "^2.23.0",
     "junit-report-builder": "^1.1.1",
     "promise": "^7.0.1",
-    "selenium-webdriver": "^2.53.0",
+    "selenium-webdriver": "^3.6.0",
     "snyk": "^1.41.1"
   },
   "contributors": [


### PR DESCRIPTION
Upgrading selenium-webdriver fixes #27 

* The `package-lock.json` should also be updated. I could not do this because I use an older version of npm (which did not have `package-lock.json` support yet) and cannot upgrade.
* Running `npm-check-updates` aka `ncu` shows many outdated packages. So you probably want to run:
  * `ncu -u`
  * `npm update`

