### PR TITLE
Add geckodriver as npm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Default value:
 ```
 {
   browser: 'firefox',
+  browserArguments: '',
   threshold: 0,
   tags: null
 }
@@ -62,6 +63,12 @@ Type: `String`
 Default value: `firefox`
 
 Which browser to run the tests in
+
+#### browserArguments
+Type: `String` or `Array` of `Strings`
+Default value: `''`
+
+This can be used to pass command line arguments when starting the browser. For example if you want to start the browser headless you can set this to `'--headless'` for Firefox or `['headless', 'disable-gpu']` for Chrome.
 
 #### tags
 Type: `String` or `Array[String]`
@@ -124,6 +131,30 @@ grunt.initConfig({
     chrome: {
       options: {
         browser: "chrome"
+      },
+      urls: ['http://localhost:9876/tests/test1.html', 'http://localhost:9876/tests/test2.html'],
+    }
+  },
+});
+```
+
+#### Starting Firefox and Chrome in headless mode
+In this example, we add some `browserArguments` to start Firefox and Chrome in headless mode. The selinium `addArguments` API has a slightly different syntax for the `firefoxDriver` and `chromeDriver`, hence it looks a bit different for each browser:
+
+```js
+grunt.initConfig({
+  "axe-webdriver": {
+    firefox: {
+      options: {
+        browser: 'firefox',
+        browserArguments: ['--headless']
+	  },
+      urls: ['http://localhost:9876/tests/test1.html', 'http://localhost:9876/tests/test2.html']
+    },
+    chrome: {
+      options: {
+        browser: 'chrome',
+        browserArguments: ['headless', 'disable-gpu']
       },
       urls: ['http://localhost:9876/tests/test1.html', 'http://localhost:9876/tests/test2.html'],
     }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,7 @@ var junitReporter = require('./junitReporter');
 var chrome = require('selenium-webdriver/chrome');
 var firefox = require('selenium-webdriver/firefox');
 require('chromedriver');
+require('geckodriver');
 
 module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 	var options = this.options({

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,22 +1,27 @@
 'use strict';
 
 var junitReporter = require('./junitReporter');
+var chrome = require('selenium-webdriver/chrome');
+var firefox = require('selenium-webdriver/firefox');
 require('chromedriver');
 
 module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 	var options = this.options({
 		browser: 'firefox',
+		browserArguments: '',
 		server: null,
 		threshold: 0,
 		tags: null
 	});
 
-	var tagsAreDefined = 
-		(!Array.isArray(options.tags) && options.tags !== null && options.tags !== '') || 
+	var tagsAreDefined =
+		(!Array.isArray(options.tags) && options.tags !== null && options.tags !== '') ||
 		(Array.isArray(options.tags) && options.tags.length > 0);
 	var done = this.async();
 	var driver = new WebDriver.Builder()
 		.forBrowser(options.browser)
+		.setChromeOptions(new chrome.Options().addArguments(options.browserArguments))
+		.setFirefoxOptions(new firefox.Options().addArguments(options.browserArguments))
 		.usingServer(options.server)
 		.build();
 
@@ -34,11 +39,11 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 				.then(function() {
 					var startTimestamp = new Date().getTime();
 					var axeBuilder = new AxeBuilder(driver);
-					
+
 					if (tagsAreDefined) {
 						axeBuilder.withTags(options.tags);
 					}
-					
+
 					axeBuilder
 						.analyze(function(results) {
 							results.url = url;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chromedriver": "^2.23.0",
     "junit-report-builder": "^1.1.1",
     "promise": "^7.0.1",
-    "selenium-webdriver": "^2.53.0",
+    "selenium-webdriver": "^3.6.0",
     "snyk": "^1.41.1"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "axe-webdriverjs": "^1.1.5",
     "chromedriver": "^2.23.0",
+    "geckodriver": "^1.10.0",
     "junit-report-builder": "^1.1.1",
     "promise": "^7.0.1",
     "selenium-webdriver": "^3.6.0",


### PR DESCRIPTION
At the moment it is necessary to install geckodriver manually which is a bit cumbersome depending on OS and prior selenium knowledge (whereas chromedriver is already setup as npm dependency). With this commit the [geckodriver](https://www.npmjs.com/package/geckodriver) is added as dependency and Firefox works out of the box (like Chrome already does).

This PR also includes the previous commits (I did not have the time to clean it up). But all of them are pretty tiny, so maybe you might just merge it all and close the others, or just cherrypick what you need (if that's ok?). 