### PR TITLE
Added `htmlDest` option using an htmlReporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ grunt.initConfig({
       }
       urls: [],
       dest: "output.json",
+      htmlDest: "output.html",
       junitDest: "output.xml"
     },
   },
@@ -95,6 +96,12 @@ Type: `String`
 Default value: undefined
 
 An optional file to which the results of the accessibility scans will be written as a JSON Array of results objects.
+
+### htmlDest
+Type: `String`
+Default value: undefined
+
+An optional file to which the results of the accessibility scans will be written as an HTML file.
 
 ### junitDest
 Type: `String`

--- a/lib/htmlReporter.js
+++ b/lib/htmlReporter.js
@@ -66,6 +66,11 @@ module.exports = function(results, htmlDest) {
 			});
 		} else {
 			html += '<h3 class="ok">Found no accessibility violations.</h3>';
+			html += `<p>
+						Please note that only 20&nbsp;% to 50&nbsp;% of all accessibility issues can be automatically detected.
+						Manual testing is always required. For more information see:<br>
+						<a target="_blank" href="https://dequeuniversity.com/curriculum/courses/testingmethods">https://dequeuniversity.com/curriculum/courses/testingmethods</a>
+					</p>`
 		}
 		html += '</section>';
 	});

--- a/lib/htmlReporter.js
+++ b/lib/htmlReporter.js
@@ -1,0 +1,82 @@
+var fs = require('fs');
+
+const head = `
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<title>HTML Report of grunt-axe-webdriver</title>
+	<style>
+		.ok {
+			color: green;
+		}
+		.error {
+			/* with just red it does not pass the axe test because contrast is too low ;) */
+			color: darkred;
+		}
+		section {
+			margin-bottom: 2em;
+		}
+	</style>
+  </head>
+`;
+
+module.exports = function(results, htmlDest) {
+	let html = head;
+	html += '<body>';
+	html += '<main>';
+	html += '<h1>HTML Report of grunt-axe-webdriver</h1>';
+	results.forEach(function(result) {
+		html += '<section>';
+		html += `<h2><a href="${result.url}">${result.url}</a></h2>`
+		var violations = result.violations;
+		if (violations.length) {
+			html += `<h3 class="error">Found ${violations.length} accessibility violations:</h3>`
+			violations.forEach(function(ruleResult) {
+				html += `<h4><span class="error">×</span> ${ruleResult.help}</h4>`;
+				html += '<ol>';
+
+				ruleResult.nodes.forEach(function(violation, index) {
+					const target = JSON.stringify(violation.target);
+					html += '<li>';
+					html += `${target}<br>`;
+
+					if (violation.any.length) {
+						html += 'Fix any of the following:<br>';
+						html += '<ul>';
+						violation.any.forEach(function(check) {
+							html += `<li>${check.message}</li>`;
+						});
+						html += '</ul>';
+					}
+
+					var alls = violation.all.concat(violation.none);
+					if (alls.length) {
+						html += 'Fix all of the following:<br>';
+						html += '<ul>';
+						alls.forEach(function(check) {
+							html += `<li>${check.message}</li>`;
+						});
+						html += '</ul>';
+					}
+					html += '</li>';
+				});
+				html += '</ol>';
+			});
+		} else {
+			html += '<h3 class="ok">Found no accessibility violations.</h3>';
+		}
+		html += '</section>';
+	});
+	html += '</main>';
+	html += '</body>';
+	html += '</html>';
+
+	fs.writeFile(htmlDest, html, function(err) {
+		if (err) {
+			return console.log(err);
+		}
+	});
+
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var htmlReporter = require('./htmlReporter');
 var junitReporter = require('./junitReporter');
 var chrome = require('selenium-webdriver/chrome');
 var firefox = require('selenium-webdriver/firefox');
@@ -28,6 +29,7 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 
 	var dest = this.data.dest;
 	var junitDest = this.data.junitDest;
+	var htmlDest = this.data.htmlDest;
 
 	if(typeof this.data.urls === 'function') {
 		this.data.urls = this.data.urls();
@@ -58,6 +60,9 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 	})).then(function(results) {
 		if (dest) {
 			grunt.file.write(dest, JSON.stringify(results, null, '  '));
+		}
+		if (htmlDest) {
+			htmlReporter(results, htmlDest);
 		}
 		if (junitDest) {
 			junitReporter(results, junitDest);


### PR DESCRIPTION
This adds an option `htmlDest`. It is similar to `dest` for json and `junitDest` for junit xml, but outputs an html file. The structure of the html file is similarly nested like the grunt console output. I needed this myself for a project where we continuously a11y check certain URLs (very few hours) and put the result on an internal webpage. It would be nice if this option/feature could be merged into upstream.