### PR TITLE
ci: use Node.js v10 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/node:6.12.3-browsers
+    - image: circleci/node:10-browsers
   working_directory: ~/grunt-axe-webdriver
 
 configure_npm: &configure_npm


### PR DESCRIPTION
This helps ensure we're using an up-to-date version of npm.