### PR TITLE
fix: prevent starting Chrome with invalid options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+example/node_modules

--- a/example/.npmrc
+++ b/example/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -1,0 +1,14 @@
+module.exports = grunt => {
+	grunt.loadTasks('../tasks');
+	grunt.initConfig({
+		'axe-webdriver': {
+			chrome: {
+				options: {
+					browser: 'chrome'
+				},
+				urls: ['http://example.com']
+			}
+		}
+	});
+	grunt.registerTask('default', ['axe-webdriver']);
+};

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,15 @@
+# grunt-axe-webdriver example
+
+> A simple, contrived example of running `grunt-axe-webdriver`.
+
+## Running the example
+
+To run the example, install its dependencies and do `npm test`.
+
+```
+$ cd example
+$ npm install
+$ npm test
+```
+
+The example **will** exit with an error intentionally, as it finds accessibility problems on [example.com](http://example.com).

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "grunt-axe-webdriver-example",
+  "private": true,
+  "scripts": {
+    "test": "grunt"
+  },
+  "dependencies": {
+    "grunt": "^1.0.4",
+    "grunt-cli": "^1.3.2"
+  }
+}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,10 +26,12 @@ module.exports = function(grunt, WebDriver, Promise, AxeBuilder, reporter) {
 		.forBrowser(options.browser)
 		.usingServer(options.server)
 
-	if (options.browser === 'chrome' && options.browserArguments) {
-		driver = driver.setChromeOptions(new chrome.Options().addArguments(options.browserArguments))
-	} else if (options.browser === 'firefox' && options.browserArguments) {
-		driver = driver.setFirefoxOptions(new firefox.Options().addArguments(options.browserArguments))
+	if (options.browserArguments && options.browserArguments.length) {
+		if (options.browser === 'chrome') {
+			driver = driver.setChromeOptions(new chrome.Options().addArguments(options.browserArguments))
+		} else if (options.browser === 'firefox') {
+			driver = driver.setFirefoxOptions(new firefox.Options().addArguments(options.browserArguments))
+		}
 	}
 	driver = driver.build();
 


### PR DESCRIPTION
This patch prevents starting Chrome with invalid options and adds an "example" which demonstrates the bug in the previous implementation.

Closes https://github.com/dequelabs/grunt-axe-webdriver/issues/39